### PR TITLE
Activate strict typing in Explorer for Endevor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "explorer-for-endevor",
-	"version": "0.9.1",
+	"version": "0.10.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -160,6 +160,7 @@
 			"version": "6.10.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
 			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -192,6 +193,7 @@
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
 			}
@@ -199,7 +201,8 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -209,12 +212,14 @@
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"dev": true
 		},
 		"aws4": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -225,6 +230,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"dev": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
@@ -264,7 +270,8 @@
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
 		},
 		"chalk": {
 			"version": "2.4.2",
@@ -398,12 +405,14 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -452,6 +461,7 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"dev": true,
 			"requires": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
@@ -496,22 +506,26 @@
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true
 		},
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
 		},
 		"fast-deep-equal": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+			"dev": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
 		},
 		"find-up": {
 			"version": "2.1.0",
@@ -529,12 +543,14 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
 		},
 		"form-data": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
 			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"dev": true,
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.6",
@@ -565,6 +581,7 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -596,12 +613,14 @@
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"dev": true
 		},
 		"har-validator": {
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
 			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"dev": true,
 			"requires": {
 				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
@@ -632,6 +651,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -676,12 +696,14 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -701,22 +723,26 @@
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true
 		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
 		},
 		"jsonfile": {
 			"version": "4.0.0",
@@ -735,6 +761,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -906,7 +933,8 @@
 		"oauth-sign": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"dev": true
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -966,7 +994,8 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
 		},
 		"pkg-up": {
 			"version": "2.0.0",
@@ -1000,17 +1029,20 @@
 		"psl": {
 			"version": "1.1.31",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+			"dev": true
 		},
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true
 		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"dev": true
 		},
 		"querystringify": {
 			"version": "2.1.1",
@@ -1027,6 +1059,7 @@
 			"version": "2.88.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
 			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
@@ -1091,12 +1124,14 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"semver": {
 			"version": "5.6.0",
@@ -1134,6 +1169,7 @@
 			"version": "1.16.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
 			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -1210,6 +1246,7 @@
 			"version": "2.4.3",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
 			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+			"dev": true,
 			"requires": {
 				"psl": "^1.1.24",
 				"punycode": "^1.4.1"
@@ -1218,7 +1255,8 @@
 				"punycode": {
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"dev": true
 				}
 			}
 		},
@@ -1279,6 +1317,7 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -1286,7 +1325,8 @@
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true
 		},
 		"typescript": {
 			"version": "3.7.4",
@@ -1303,6 +1343,7 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -1320,12 +1361,14 @@
 		"uuid": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"dev": true
 		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
             "scope": "resource",
             "properties": {
                 "endevor.connections": {
-                    "type":"array",
+                    "type": "array",
                     "title": "Endevor Connections",
                     "items": {
                         "type": "object",
@@ -235,7 +235,7 @@
                                     ],
                                     "properties": {
                                         "profile": {
-                                            "type":"string",
+                                            "type": "string",
                                             "description": "Profile attached to"
                                         },
                                         "name": {

--- a/src/EndevorController.ts
+++ b/src/EndevorController.ts
@@ -59,9 +59,11 @@ export class EndevorController {
             repo.id = this.findNextId(connectionLabel);
         }
         const newRepoNode: EndevorNode = new EndevorNode(repo);
-        this.connections.get(connectionLabel).loadRepository(repo);
+        const conn = this.connections.get(connectionLabel);
+        if (conn) { conn.loadRepository(repo); }
         this._rootNode.children.forEach(child => {
-            if (child.getEntity().getName() === connectionLabel) {
+            const entity = child.getEntity();
+            if (entity && entity.getName() === connectionLabel) {
                 child.children.push(newRepoNode);
             }
         });
@@ -71,6 +73,7 @@ export class EndevorController {
         return Array.from(this.connections.values());
     }
     public addConnection(connection: Connection) {
+        if (!connection.name) { connection.name = "" }
         this.connections.set(connection.name, connection);
         const newConnectionNode = new EndevorNode(connection);
         this._rootNode.children.push(newConnectionNode);
@@ -86,7 +89,10 @@ export class EndevorController {
     }
 
     public removeRepository(repoName: string, connectionLabel: string) {
-        this.connections.get(connectionLabel).getRepositoryMap().delete(repoName);
+        const conn = this.connections.get(connectionLabel);
+        if (conn) {
+            conn.getRepositoryMap().delete(repoName);
+        }
         this._rootNode.children.forEach((connection, index) => {
             if (connection.label === connectionLabel) {
                 this._rootNode.children[index].children = connection.children.filter(repo => repo.label !== repoName);
@@ -94,18 +100,21 @@ export class EndevorController {
         });
     }
 
-    public updateRepositoryName(oldRepoName: string, newRepoName: string, connectionlabel: string) {
+    public updateRepositoryName(oldRepoName: string, newRepoName: string, connectionLabel: string) {
         const newMap = new Map();
-        this.connections.get(connectionlabel).getRepositoryMap().forEach((repo, name) => {
-            if (name === oldRepoName) {
-                repo.setName(newRepoName);
-                newMap.set(newRepoName, repo);
-            } else {
-                newMap.set(name, repo);
-            }
-        });
-        this.connections.get(connectionlabel).repositories = newMap;
-        const cnxIdx = this.rootNode.children.findIndex(node => node.label === connectionlabel);
+        const conn = this.connections.get(connectionLabel);
+        if (conn) {
+            conn.getRepositoryMap().forEach((repo, name) => {
+                if (name === oldRepoName) {
+                    repo.setName(newRepoName);
+                    newMap.set(newRepoName, repo);
+                } else {
+                    newMap.set(name, repo);
+                }
+            });
+            conn.repositories = newMap;
+        }
+        const cnxIdx = this.rootNode.children.findIndex(node => node.label === connectionLabel);
         const repoIdx = this.rootNode.children[cnxIdx].children.findIndex(repo => repo.label === oldRepoName);
         this.rootNode.children[cnxIdx].children[repoIdx].label = newRepoName;
     }
@@ -164,17 +173,25 @@ export class EndevorController {
                     }
                     updatedRepos.set(repoToKeep.getName(), repoToKeep);
                 });
-                let currentRepos = this.connections.get(connName).repositories;
-                currentRepos = updatedRepos;
-                currentRepos.forEach(repo => EndevorController.instance.addRepository(repo, repo.getProfileLabel()));
+                let currentRepos = updatedRepos;
+                currentRepos.forEach(repo =>  {
+                    let profileLabel = repo.getProfileLabel();
+                    if (!profileLabel) { profileLabel = "" }
+                    EndevorController.instance.addRepository(repo, profileLabel);
+                })
                 this.updateIDs(connName);
             }
         });
     }
 
+
     public isRepoInConnection(repoName: string, connectionLabel: string): boolean {
-        const repoMap = this.connections.get(connectionLabel).getRepositoryMap();
-        return repoMap.get(repoName) ? true : false ;
+        const conn = this.connections.get(connectionLabel);
+        if (conn) {
+            const repoMap = conn.getRepositoryMap();
+            return repoMap.get(repoName) ? true : false;
+        }
+        return false;
     }
 
     // tslint:disable-next-line: member-ordering
@@ -183,12 +200,15 @@ export class EndevorController {
             return undefined;
         }
         const connection = this.findNodeByConnectionName(connectionLabel);
-        for (const node of connection.children) {
-            const nodeRepo: Repository | undefined = node.getRepository();
-            if (nodeRepo && nodeRepo.id === id) {
-                return node;
+        if (connection) {
+            for (const node of connection.children) {
+                const nodeRepo: Repository | undefined = node.getRepository();
+                if (nodeRepo && nodeRepo.id === id) {
+                    return node;
+                }
             }
         }
+        return undefined;
     }
 
     // tslint:disable-next-line: member-ordering
@@ -197,7 +217,7 @@ export class EndevorController {
             return undefined;
         }
         for (const node of this._rootNode.children) {
-            if (node.getEntity().getName() === name) {
+            if (node.getEntity() && node.getEntity()!.getName() === name) {
                 return node;
             }
         }
@@ -207,20 +227,24 @@ export class EndevorController {
      * Function used to determine next available `id`.
      */
     public findNextId(connectionLabel: string): number {
-        const repoMap = this.connections.get(connectionLabel).getRepositoryMap();
-        let iDArray: boolean[] = new Array(repoMap.size);
-        iDArray.fill(true);
-        repoMap.forEach(repo => {
-            if (repo.id !== undefined) {
-                iDArray[repo.id] = false;
+        const conn = this.connections.get(connectionLabel);
+        if (conn) {
+            const repoMap = conn.getRepositoryMap();
+            let iDArray: boolean[] = new Array(repoMap.size);
+            iDArray.fill(true);
+            repoMap.forEach(repo => {
+                if (repo.id !== undefined) {
+                    iDArray[repo.id] = false;
+                }
+            });
+            for (let i = 0; i < iDArray.length; i++) {
+                if (iDArray[i]) {
+                    return i;
+                }
             }
-        });
-        for (let i = 0; i < iDArray.length; i++) {
-            if (iDArray[i]) {
-                return i;
-            }
+            return iDArray.length;
         }
-        return iDArray.length;
+        return -1;
     }
 
 /**
@@ -228,16 +252,19 @@ export class EndevorController {
  * and store in the settings.json.
  */
     private updateIDs(connectionLabel: string) {
-        const repoMap = this.connections.get(connectionLabel).getRepositoryMap();
-        let saveRepos: boolean = false;
-        repoMap.forEach(repo => {
-            if (repo.id === undefined) {
-                repo.id = EndevorController.instance.findNextId(connectionLabel);
-                saveRepos = true;
+        const conn = this.connections.get(connectionLabel);
+        if (conn) {
+            const repoMap = conn.getRepositoryMap();
+            let saveRepos: boolean = false;
+            repoMap.forEach(repo => {
+                if (repo.id === undefined) {
+                    repo.id = EndevorController.instance.findNextId(connectionLabel);
+                    saveRepos = true;
+                }
+            });
+            if (saveRepos) {
+                this.updateSettings();
             }
-        });
-        if (saveRepos) {
-            this.updateSettings();
         }
     }
 

--- a/src/commands/DeleteHost.ts
+++ b/src/commands/DeleteHost.ts
@@ -22,7 +22,8 @@ export function deleteHost(arg:any){
         if (repo) {
             vscode.window.showWarningMessage("Remove Configuration: " + repo.getName() + "?", "OK").then(message => {
                 if (message === "OK") {
-                    EndevorController.instance.removeRepository(repo.getName(), repo.getProfileLabel());
+                    const profileLabel = repo.getProfileLabel() ? repo.getProfileLabel() : "";
+                    EndevorController.instance.removeRepository(repo.getName(), profileLabel!);
                     EndevorController.instance.updateSettings();
                 }
             });

--- a/src/model/Connection.ts
+++ b/src/model/Connection.ts
@@ -81,14 +81,14 @@ export class Connection extends EndevorEntity implements IProfileLoaded {
         return this;
     }
 
-    public getName(): string {
+    public getName(): string | undefined {
         return this.name;
     }
     public getDescription(): string {
         return "";
     }
 
-    public getProfile(): IProfile {
+    public getProfile(): IProfile | undefined {
         return this.profile;
     }
 

--- a/src/model/EndevorEntity.ts
+++ b/src/model/EndevorEntity.ts
@@ -15,7 +15,7 @@
 import { Repository } from "./Repository";
 
 export abstract class EndevorEntity {
-    abstract getName(): string;
+    abstract getName(): string | undefined;
     abstract getDescription(): string;
     abstract getRepository(): Repository;
 }

--- a/src/model/IConnection.ts
+++ b/src/model/IConnection.ts
@@ -16,10 +16,10 @@ import { IProfile } from "@zowe/imperative";
 
 export interface IConnection extends IProfile {
     name: string;
-    host: string;
-    port: number;
-    user: string;
-    password: string;
-    rejectUnauthorized: boolean;
-    protocol: string;
+    host: string | undefined;
+    port: number | undefined;
+    user: string | undefined;
+    password: string | undefined;
+    rejectUnauthorized: boolean | undefined;
+    protocol: string | undefined;
 }

--- a/src/model/IEndevorInstance.ts
+++ b/src/model/IEndevorInstance.ts
@@ -18,7 +18,7 @@ export interface Host {
     id?: number;
     name: string;
     url: string;
-    username: string;
+    username?: string;
     password?: string;
     datasource: string;
     filters?: Filter[];

--- a/src/model/Repository.ts
+++ b/src/model/Repository.ts
@@ -22,15 +22,15 @@ export class Repository extends EndevorEntity {
     private _id?: number;
     private name: string;
     private url: string;
-    private username: string;
+    private username: string | undefined;
     private password: string | undefined;
     private datasource: string;
     private _environments: Map<string, Environment>;
     private _filters: EndevorFilter[];
     private _map: EndevorFilter;
-    private _profileLabel: string;
+    private _profileLabel: string | undefined;
 
-    constructor(name: string, url: string, username: string, password: string | undefined, datasource: string, profileLabel: string, id?: number) {
+    constructor(name: string, url: string, username: string | undefined, password: string | undefined, datasource: string, profileLabel: string | undefined, id?: number) {
         super();
         this._id = id;
         this.name = name;
@@ -109,7 +109,7 @@ export class Repository extends EndevorEntity {
         this._profileLabel = value;
     }
 
-    public getProfileLabel(): string {
+    public getProfileLabel(): string | undefined {
         return this._profileLabel;
     }
 
@@ -121,7 +121,7 @@ export class Repository extends EndevorEntity {
         this.username = value;
     }
 
-    public getUsername(): string {
+    public getUsername(): string | undefined {
         return this.username;
     }
 

--- a/src/service/EndevorCliProxy.ts
+++ b/src/service/EndevorCliProxy.ts
@@ -73,7 +73,11 @@ export async function proxyListType(repository: Repository, endevorQualifier: En
     const requestBody = ListType.setupListTypeRequest({});
     const listResponse = await ListType.listType(session, instance, typeInput, requestBody);
     if (listResponse.returnCode > 0) {
-        logger.error(listResponse.messages[1] ?? listResponse.messages[0], listResponse.messages.toString());
+        logger.error(
+          listResponse.messages ?
+          listResponse.messages[1] ?? listResponse.messages[0]
+          : "Error retrieving element type",
+          listResponse.messages?.toString());
     }
     return toArray(listResponse.data);
 }
@@ -86,7 +90,11 @@ export async function proxyListElement(repository: Repository,
     const requestBody = ListElement.setupListElementRequest({});
     const listResponse = await ListElement.listElement(session, instance, endevorElement, requestBody);
     if (listResponse.returnCode > 0) {
-        logger.error(listResponse.messages[1] ?? listResponse.messages[0], listResponse.messages.toString());
+        logger.error(listResponse.messages ?
+          listResponse.messages[1] ?? listResponse.messages[0]
+          : "Error retrieving element",
+          listResponse.messages?.toString(),
+        );
     }
     return toArray(listResponse.data);
 }
@@ -98,7 +106,11 @@ export async function proxyListEnvironment(repository: Repository): Promise<IEnv
     const requestBody = ListEnvironment.setupListEnvironmentRequest({});
     const envResponse = await ListEnvironment.listEnvironment(session, instance, environment, requestBody);
     if (envResponse.returnCode > 0) {
-        logger.error(envResponse.messages[1] ?? envResponse.messages[0], envResponse.messages.toString());
+        logger.error(envResponse.messages ?
+          envResponse.messages[1] ??  envResponse.messages[0]
+          : "Error retrieving environment",
+          envResponse.messages?.toString(),
+        );
     }
     return toArray(envResponse.data);
 }
@@ -111,7 +123,11 @@ export async function proxyListStage(repository: Repository,
     const requestBody = ListStage.setupListStageRequest({});
     const listResponse = await ListStage.listStage(session, instance, stageNumber, requestBody);
     if (listResponse.returnCode > 0) {
-        logger.error(listResponse.messages[1] ?? listResponse.messages[0], listResponse.messages.toString());
+        logger.error(listResponse.messages ?
+          listResponse.messages[1] ?? listResponse.messages[0]
+          : "Error retrieving stage",
+          listResponse.messages?.toString(),
+        );
     }
     return toArray(listResponse.data);
 }
@@ -128,8 +144,11 @@ export async function proxyListSubsystem(repository: Repository,
         endevorSubsystem,
         requestBody);
     if (listSubsystemResponse.returnCode > 0) {
-        logger.error(listSubsystemResponse.messages[1] ?? listSubsystemResponse.messages[0],
-            listSubsystemResponse.messages.toString());
+        logger.error(listSubsystemResponse.messages ?
+          listSubsystemResponse.messages[1] ?? listSubsystemResponse.messages[0]
+          : "Error retrieving subsystem",
+          listSubsystemResponse.messages?.toString(),
+        );
     }
     return toArray(listSubsystemResponse.data);
 }
@@ -142,8 +161,11 @@ export async function proxyListSystem(repository: Repository,
     const requestBody = ListSystem.setupListSystemRequest({});
     const listSystemResponse = await ListSystem.listSystem(session, instance, endevorSystem, requestBody);
     if (listSystemResponse.returnCode > 0) {
-        logger.error(listSystemResponse.messages[1] ?? listSystemResponse.messages[0],
-            listSystemResponse.messages.toString());
+        logger.error(listSystemResponse.messages ?
+          listSystemResponse.messages[1] ?? listSystemResponse.messages[0]
+          : "Error retrieving subsystem",
+          listSystemResponse.messages?.toString(),
+        );
     }
     return toArray(listSystemResponse.data);
 }

--- a/src/service/Profiles.ts
+++ b/src/service/Profiles.ts
@@ -11,7 +11,6 @@
 
 import { CliProfileManager, ImperativeConfig, IProfile, IProfileLoaded, ISession, Logger, Session } from "@zowe/imperative";
 import { EndevorProfilesConfig } from "@broadcom/endevor-for-zowe-cli";
-import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { URL } from "url";
@@ -20,9 +19,9 @@ import { IConnection } from "../model/IConnection";
 
 interface IUrlValidator {
     valid: boolean;
-    host: string;
-    port: number;
-    protocol: string;
+    host: string | undefined;
+    port: number | undefined;
+    protocol: string | undefined;
 }
 
 export class Profiles {
@@ -36,10 +35,10 @@ export class Profiles {
         return Profiles.loader;
     }
 
-    private endevorProfileManager: CliProfileManager;
+    private endevorProfileManager!: CliProfileManager;
     private static loader: Profiles;
     public allProfiles: IProfileLoaded[] = [];
-    public defaultProfile: IProfileLoaded;
+    public defaultProfile: IProfileLoaded | undefined;
 
     private spawnValue: number = -1;
     private initValue: number = -1;
@@ -54,7 +53,7 @@ export class Profiles {
         throw new Error("Could not find profile named: "
             + name + ".");
     }
-    public getDefaultProfile(): IProfileLoaded {
+    public getDefaultProfile(): IProfileLoaded | undefined {
         return this.defaultProfile;
     }
     public async refresh() {
@@ -66,7 +65,7 @@ export class Profiles {
         });
         if (endevorProfiles && endevorProfiles.length > 0) {
             this.allProfiles.push(...endevorProfiles);
-            let defaultProfile: IProfileLoaded;
+            let defaultProfile: IProfileLoaded | undefined;
             try {
                 defaultProfile = await (await profileManager).load({ loadDefault: true});
                 this.defaultProfile = defaultProfile ? defaultProfile : undefined;
@@ -86,9 +85,9 @@ export class Profiles {
 
         const validationResult: IUrlValidator = {
             valid: false,
-            host: null,
-            port: null,
-            protocol: null,
+            host: undefined,
+            port: undefined,
+            protocol: undefined,
         };
 
         try {
@@ -129,9 +128,9 @@ export class Profiles {
     }
 
     public async createNewConnection(profileName: string): Promise<string | undefined> {
-        let userName: string;
-        let passWord: string;
-        let endevorURL: string;
+        let userName: string | undefined;
+        let passWord: string | undefined;
+        let endevorURL: string | undefined;
         let rejectUnauthorize: boolean;
         let options: vscode.InputBoxOptions;
 
@@ -153,8 +152,7 @@ export class Profiles {
 
         options = {
             placeHolder: "Optional: User Name",
-            prompt: "Enter the user name for the connection. Leave blank to not store.",
-            value: userName,
+            prompt: "Enter the user name for the connection. Leave blank to not store."
         };
         userName = await vscode.window.showInputBox(options);
 
@@ -166,8 +164,7 @@ export class Profiles {
         options = {
             placeHolder: "Optional: Password",
             prompt: "Enter the password for the connection. Leave blank to not store.",
-            password: true,
-            value: passWord,
+            password: true
         };
         passWord = await vscode.window.showInputBox(options);
 
@@ -219,13 +216,13 @@ export class Profiles {
 
         try {
             newProfile = await this.saveProfile(connection, connection.name, "endevor");
+            await this.createBasicEndevorSession(newProfile);
+            vscode.window.showInformationMessage("Profile " + profileName + " was created.");
+            await this.refresh();
+            return profileName;
         } catch (error) {
             vscode.window.showErrorMessage(error.message);
         }
-        await this.createBasicEndevorSession(newProfile);
-        vscode.window.showInformationMessage("Profile " + profileName + " was created.");
-        await this.refresh();
-        return profileName;
     }
 
     public async createBasicEndevorSession(profile) {
@@ -243,19 +240,17 @@ export class Profiles {
     }
 
     public async promptCredentials(sessName) {
-        let userName: string;
-        let passWord: string;
+        let userName: string | undefined;
+        let passWord: string | undefined;
         let options: vscode.InputBoxOptions;
 
         const loadProfile = this.loadNamedProfile(sessName);
         const loadSession = loadProfile.profile as ISession;
 
         if (!loadSession.user) {
-
             options = {
                 placeHolder: "User Name",
-                prompt: "Enter the user name for the connection",
-                value: userName,
+                prompt: "Enter the user name for the connection"
             };
             userName = await vscode.window.showInputBox(options);
 
@@ -297,7 +292,9 @@ export class Profiles {
                     {
                         configuration: EndevorProfilesConfig,
                         profileRootDirectory: path.join(this.getZoweDir(), "profiles"),
-                        reinitialize: false});
+                        reinitialize: false
+                    }
+                );
                 profileManager = new CliProfileManager({
                     profileRootDirectory: path.join(this.getZoweDir(), "profiles"),
                     type: "endevor",
@@ -323,9 +320,9 @@ export class Profiles {
         let endevorProfile: IProfile;
         try {
             endevorProfile = await (await this.getEndevorCliProfileManager()).save({ profile: ProfileInfo, name: ProfileName, type: ProfileType });
+            return endevorProfile.profile;
         } catch (error) {
             vscode.window.showErrorMessage(error.message);
         }
-        return endevorProfile.profile;
     }
 }

--- a/src/service/RetrieveElementService.ts
+++ b/src/service/RetrieveElementService.ts
@@ -39,7 +39,7 @@ export class RetrieveElementService {
             fs.mkdirSync(typeDirectory);
         }
         const filePath: string = path.join(typeDirectory, elementName + (ext ? "." + ext : ""));
-        fs.writeFileSync(filePath, data);
+        fs.writeFileSync(filePath, data!);
 
         return filePath;
     }

--- a/src/service/RetrieveElementService.ts
+++ b/src/service/RetrieveElementService.ts
@@ -32,7 +32,8 @@ export class RetrieveElementService {
     ): Promise<string> {
         const data = await proxyRetrieveElement(repo, eq);
         const ext = await this.getExtension(repo, eq);
-        const typeDirectory = path.join(workspace.uri.fsPath, eq.type);
+        const type = eq.type ? eq.type : "";
+        const typeDirectory = path.join(workspace.uri.fsPath, type);
         if (!fs.existsSync(typeDirectory)) {
             fs.mkdirSync(typeDirectory);
         }

--- a/src/service/SettingsFacade.ts
+++ b/src/service/SettingsFacade.ts
@@ -30,39 +30,43 @@ export class SettingsFacade {
     public static listRepositories(connectionLabel: string): Repository[] {
         const repos: Repository[] = [];
         // tslint:disable-next-line: max-line-length
-        const connectionInSettings = vscode.workspace.getConfiguration().get(HOST_SETTINGS_KEY, []).find(connection => connection.name === connectionLabel);
+        const allConnectionsInSettings: any[] = vscode.workspace.getConfiguration().get(HOST_SETTINGS_KEY, []);
+        const connectionInSettings = allConnectionsInSettings.find(connection => connection.name === connectionLabel);
         const hosts: Host[] = connectionInSettings ? connectionInSettings.hosts : [];
         const profile = Profiles.getInstance().loadNamedProfile(connectionLabel).profile;
-        hosts.forEach(host => {
-            const repo: Repository = new Repository(
-                host.name,
-                `${profile.protocol}://${profile.host}:${profile.port}`,
-                profile.user,
-                profile.password,
-                host.datasource,
-                host.profileLabel,
-                host.id,
-            );
-            if (host.filters) {
-                const newFilters: Map<string, EndevorFilter> = new Map();
-                host.filters.forEach(filter => {
-                    newFilters.set(filter.uri, new EndevorFilter(repo, filter.uri));
-                    repo.filters.push(new EndevorFilter(repo, filter.uri));
-                });
-                repo.filters = Array.from(newFilters.values());
-            }
-            repos.push(repo);
-        });
+        if (profile) {
+            hosts.forEach(host => {
+                const repo: Repository = new Repository(
+                    host.name,
+                    `${profile.protocol}://${profile.host}:${profile.port}`,
+                    profile.user,
+                    profile.password,
+                    host.datasource,
+                    host.profileLabel,
+                    host.id,
+                );
+                if (host.filters) {
+                    const newFilters: Map<string, EndevorFilter> = new Map();
+                    host.filters.forEach(filter => {
+                        newFilters.set(filter.uri, new EndevorFilter(repo, filter.uri));
+                        repo.filters.push(new EndevorFilter(repo, filter.uri));
+                    });
+                    repo.filters = Array.from(newFilters.values());
+                }
+                repos.push(repo);
+            });
+        }
         return repos;
     }
 
     public static async updateSettings(connections: Connection[]) {
-        const conns = [];
+        const conns: any[] = [];
         connections.forEach(connection => {
+            const hostsArray: any[] = [];
             const toPush = {
                 name: connection.getName(),
                 // tslint:disable-next-line: object-literal-sort-keys
-                hosts: [],
+                hosts: hostsArray
             };
             connection.getRepositoryList().forEach(repo => {
                 toPush.hosts.push({
@@ -98,7 +102,7 @@ export class SettingsFacade {
                 name: repo.getName(),
                 profileLabel: repo.getProfileLabel(),
                 url: repo.getUrl(),
-                username: repo.getUsername(),
+                username: repo.getUsername()
             });
         });
         const value = {

--- a/src/ui/tree/CredentialsInput.ts
+++ b/src/ui/tree/CredentialsInput.ts
@@ -37,13 +37,14 @@ export class CredentialsInputBox {
         EndevorController.instance.updateSettings();
         return { password, username };
     }
-    private static async showUserName(username: string): Promise<string | undefined> {
+    private static async showUserName(username?: string): Promise<string | undefined> {
+        username = username ? username : "";
         return vscode.window.showInputBox({
             ignoreFocusOut: true,
             placeHolder: "Username",
             prompt: "Enter the Username ",
             validateInput: (text: string) => (text !== "" ? "" : "Username must not be empty"),
-            value: username,
+            value: username
         });
     }
     private static async showPasswordBox(): Promise<string | undefined> {

--- a/src/ui/tree/EndevorDataProvider.ts
+++ b/src/ui/tree/EndevorDataProvider.ts
@@ -45,12 +45,13 @@ export class EndevorDataProvider implements vscode.TreeDataProvider<EndevorNode>
         } else {
             const endevorProfiles = Profiles.getInstance().allProfiles;
             for (const endevorProfile of endevorProfiles) {
-                if (this._sessionNodes.find(tempNode => tempNode.label.trim() === endevorProfile.name)) {
+                if (this._sessionNodes.find(tempNode => tempNode.label && tempNode.label.trim() === endevorProfile.name)) {
                     continue;
                 }
             }
-            if (this._sessionNodes.length === 0) {
-                this.addSingleSession(Profiles.getInstance().defaultProfile);
+            const defaultProfile = Profiles.getInstance().defaultProfile;
+            if (this._sessionNodes.length === 0 && defaultProfile) {
+                this.addSingleSession(defaultProfile);
             }
         }
         this.refresh();
@@ -66,8 +67,11 @@ export class EndevorDataProvider implements vscode.TreeDataProvider<EndevorNode>
             const newChildren: EndevorNode[] = [];
             connections.forEach(connection => {
                 const newConnectionNode: EndevorNode = new EndevorNode(connection);
-                const foundConnection: EndevorNode | undefined = EndevorController.instance.findNodeByConnectionName(
-                    connection.getName());
+                let foundConnection: EndevorNode | undefined;
+                const connectionName = connection.getName();
+                if (connectionName) {
+                    foundConnection = EndevorController.instance.findNodeByConnectionName(connectionName);
+                }
                 if (foundConnection && foundConnection.needReload) {
                     newConnectionNode.children = foundConnection.children;
                     newConnectionNode.needReload = false;
@@ -133,7 +137,7 @@ export class EndevorDataProvider implements vscode.TreeDataProvider<EndevorNode>
     }
 
     private async addSingleSession(endevorProfile: IProfileLoaded) {
-        if (this._sessionNodes.find(tempNode => tempNode.label.trim() === endevorProfile.name)) {
+        if (this._sessionNodes.find(tempNode => tempNode.label && tempNode.label.trim() === endevorProfile.name)) {
             return;
         }
         const session = await Profiles.getInstance().createBasicEndevorSession(endevorProfile.profile);

--- a/src/ui/tree/EndevorNodes.ts
+++ b/src/ui/tree/EndevorNodes.ts
@@ -40,7 +40,8 @@ export class EndevorNode extends vscode.TreeItem {
     private _needReload: boolean;
 
     constructor(entity?: EndevorEntity) {
-        super(entity ? entity.getName() : "unknown", vscode.TreeItemCollapsibleState.Collapsed);
+        const entityName = entity ? entity.getName() : "unknown";
+        super(entityName!, vscode.TreeItemCollapsibleState.Collapsed);
         this._needReload = true;
         this.description = "";
         this._children = [];
@@ -529,9 +530,9 @@ export class TypeNode extends EndevorQualifiedNode {
 }
 
 export class ConnectionNode extends EndevorNode {
-    private _session: Session;
-    private _connection: Connection;
-    private _connectionName: string;
+    private _session: Session | undefined = undefined;
+    private _connection: Connection | undefined = undefined;
+    private _connectionName: string | undefined = undefined;
 
     constructor(session?: Session, label?: string, connection?: Connection) {
         super();
@@ -546,14 +547,14 @@ export class ConnectionNode extends EndevorNode {
         }
     }
 
-    public getProfileName(): string {
+    public getProfileName(): string | undefined {
         return this._connectionName;
     }
 
-    public getConnection(): Connection {
+    public getConnection(): Connection | undefined {
         return this._connection;
     }
-    public getSession(): Session {
+    public getSession(): Session | undefined {
         return this._session;
     }
 

--- a/src/ui/views/HostPanel.ts
+++ b/src/ui/views/HostPanel.ts
@@ -52,7 +52,7 @@ export class HostPanel {
                         const datasource = message.data.configuration;
 
                         const targetRepo: Repository = new Repository(name, url, username, password, datasource, "");
-                        EndevorController.instance.addRepository(targetRepo, null);
+                        EndevorController.instance.addRepository(targetRepo, "");
                         EndevorController.instance.updateSettings();
                         panel.dispose();
                         break;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
         ],
         "sourceMap": true,
         "rootDir": "src",
-        "strict": false, /* enable all strict type-checking options */
+        "strict": true, /* enable all strict type-checking options */
         /* Additional Checks */
         "noImplicitAny": false
         // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,6 @@
         ],
         "skipLibCheck": true,
         "sourceMap": true,
-        "rootDir": "src",
         "strict": true, /* enable all strict type-checking options */
         /* Additional Checks */
         "noImplicitAny": false


### PR DESCRIPTION
Strict typing should be enabled in Explorer for Endevor. So in this PR, the `strict` option for compilation has been turned on, and all related errors have been fixed.

Changelog: Activated strict typing in the Typescript compiler options