### PR TITLE
fix option name for audit level

### DIFF
--- a/.github/workflows/Explorer-for-Endevor-CI.yml
+++ b/.github/workflows/Explorer-for-Endevor-CI.yml
@@ -37,7 +37,7 @@ jobs:
 
       # run audit on 1 system to avoid overloading the audit API
       - name: Audit from Windows / Node 12.x
-        run: npm audit --production --level=moderate
+        run: npm audit --production --audit-level=moderate
         if: matrix.os == 'windows-latest' && matrix.node-version == '12.x'
 
       - name: Extension Test


### PR DESCRIPTION
Make `npm audit` pass when finding `low` level threats. 
Was failing on node12+windows by returning an exit code of 1 instead of 0 even if threats found was categorized as low.

Signed-off-by: Alexandru-Paul Dumitru <alexandru.dumitru@broadcom.com>