### PR TITLE
Issue #78: Fixed profile loading issue in Che

### DIFF
--- a/src/commands/HostDialogs.ts
+++ b/src/commands/HostDialogs.ts
@@ -27,6 +27,7 @@ import { logger } from '../globals';
 
 export class HostDialogs {
   public static async addConnection() {
+    await Profiles.getInstance().refresh();
     const allProfiles = Profiles.getInstance().allProfiles;
     const createNewProfile = 'Create a New Endevor Profile';
     let chosenProfile: string;


### PR DESCRIPTION
This fixes the issue where a new profile created in the CLI will not show up in the `addConnection` profiles list until VSCode is restarted.

Signed-off-by: katelynienaber <katelyn.nienaber@broadcom.com>