### PR TITLE
Add telemetry API key variable to release workflow

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -5,6 +5,7 @@ on:
       - master
 env:
   PROJECT_NAME: explorer-for-endevor
+  E4E_TELEMETRY_KEY: ${{ secrets.E4E_TELEMETRY_KEY }}
 jobs:
   build-package-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Roman Kupriyanov <roman.kupriyanov@broadcom.com>

Add new `E4E_TELEMETRY_KEY` env variable for release pipeline.