### PR TITLE
Patch release 1.4.1 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ You can find all notable changes to Explorer for Endevor in this document.
 
 ### Changed
 
-- Element CCID is now optional element attribute because with the certain Endevor configurations the CCID may not be specified at all.
+- Element CCID is now optional element attribute because with certain Endevor configurations the CCID may not be specified at all.
 
 ## [1.4.0] &ndash; 2023-01-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ You can find all notable changes to Explorer for Endevor in this document.
 
 ### Fixed
 
-- Fixed an issue with the element fetching stuck in a loop after recovering from invalid credentials.
+- Fixed an issue with an infinite element-fetching loop after recovering from invalid credentials.
 
 ### Changed
 
-- Element CCID is now optional element attribute because with certain Endevor configurations the CCID may not be specified at all.
+- Element CCID is now an optional element attribute due to specific Endevor configurations where the CCID may not be specified at all.
 
 ## [1.4.0] &ndash; 2023-01-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 You can find all notable changes to Explorer for Endevor in this document.
 
-## [1.4.0] &ndash; 2023-01-26
+## [1.4.1] &ndash; 2023-01-26
+
+### Fixed
+
+- Fixed an issue with the element fetching stuck in a loop after recovering from invalid credentials.
+
+### Changed
+
+- Element CCID is now optional element attribute because with the certain Endevor configurations the CCID may not be specified at all.
+
+## [1.4.0] &ndash; 2023-01-13
 
 ### Added
 

--- a/packages/explorer-for-endevor/package.json
+++ b/packages/explorer-for-endevor/package.json
@@ -3,7 +3,7 @@
   "displayName": "Explorer for Endevor",
   "description": "Extension that modernizes the way you interact with Endevor inventory locations and elements",
   "author": "Broadcom",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "publisher": "BroadcomMFD",
   "homepage": "https://github.com/eclipse/che-che4z-explorer-for-endevor",
   "repository": {


### PR DESCRIPTION
### Fixed

- Fixed an issue with an infinite element-fetching loop after recovering from invalid credentials.

### Changed

- Element CCID is now an optional element attribute due to specific Endevor configurations where the CCID may not be specified at all.